### PR TITLE
Some small fixes 

### DIFF
--- a/gc-test/simple.rb
+++ b/gc-test/simple.rb
@@ -1,0 +1,9 @@
+#require 'GC'
+
+#gc.disable
+#Shallow graph
+1000000.times do
+  Hash.new
+end
+# GC.enable
+# GC.start

--- a/gc.c
+++ b/gc.c
@@ -2456,7 +2456,8 @@ gc_lazy_sweep(rb_objspace_t *objspace)
             return TRUE;
         }
     }
-    gc_marks(objspace);
+    //    gc_marks(objspace);
+    gc_mark_parallel(objspace);
 
     before_gc_sweep(objspace);
     if (objspace->heap.free_min > (heaps_used * HEAP_OBJ_LIMIT - objspace->heap.live_num)) {


### PR DESCRIPTION
Sorry for the pull request to a non master branch; I figured this branch had become a de facto master for a little bit, so I didn't want to push to it directly.

Fixes included here: 
-   Added some calls to destructors for deques where appropriate.
-  Changed an external call to gc_marks to a call to gc_mark_parallel (was causing mark_defer to be called prior to queue initialization)
- Added a VERY simple Ruby script for debugging purposes (there's probably a benchmark like this extant somewhere, but I couldn't find it). Currently, when I run this script using miniruby, I get the following stacktrace: https://gist.github.com/4067580
