### PR TITLE
Fix segfault in mark_locations_array

### DIFF
--- a/test_offer_work.c
+++ b/test_offer_work.c
@@ -1,0 +1,22 @@
+#include "ruby/ruby.h"
+#include <stdio.h>
+
+extern void gc_mark_defer(void *objspace, VALUE ptr, int lev);
+extern void gc_mark_parallel(void* objspace);
+
+void gc_do_mark(void* objspace, VALUE ptr) {
+
+}
+
+void gc_start_mark(void* objspace) {
+    int i;
+    for (i = 0; i < 200; i++) {
+        gc_mark_defer(objspace, i, 1);
+    }
+}
+
+int main(int argc, char** argv) {
+    gc_mark_parallel(NULL);
+    return 0;
+}
+


### PR DESCRIPTION
This commit fixes a segfault in mark_locations_array. 

This segfault was a result of treating one of the pthread's stacks as the stack of the thread starting garbage collection. When mark_current_machine_context saves the current machine state into a jump buffer, it was using the wrong stack, causing mark_locations_array to be called with weird arguments which eventually led to a segfault. 

Perhaps predictably, shit still does not work, but garbage collection will now complete a single pass on gc-test/simple.rb. 
