### PR TITLE
Added tests for deque; fixed several bugs

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -378,6 +378,14 @@ test-rubyspec-precheck:
 INSNS	= opt_sc.inc optinsn.inc optunifs.inc insns.inc insns_info.inc \
 	  vmtc.inc vm.inc
 
+
+TEST_INCFLAGS= -I. -I./include/ -I.ext/include/i686-linux/
+TEST_FLAGS=-pthread
+TEST_SOURCES=unittest/deque_test.c unittest/mocks.c
+gc-unittest: unittest/*.c
+	gcc $(TEST_INCFLAGS) $(TEST_FLAGS) $(CFLAGS) $(TEST_SOURCES) -o unittest.o
+	./unittest.o
+
 $(INSNS): $(srcdir)/insns.def vm_opts.h \
 	  $(srcdir)/defs/opt_operand.def $(srcdir)/defs/opt_insn_unif.def \
 	  $(srcdir)/tool/instruction.rb $(srcdir)/tool/insns2vm.rb

--- a/gc-test/simple.rb
+++ b/gc-test/simple.rb
@@ -2,8 +2,8 @@
 
 #gc.disable
 #Shallow graph
-1000000.times do
-  Hash.new
+100000.times do
+  Object.new
 end
 # GC.enable
 # GC.start

--- a/gc.c
+++ b/gc.c
@@ -1634,18 +1634,18 @@ gc_mark(rb_objspace_t *objspace, VALUE ptr, int lev)
     obj->as.basic.flags |= FL_MARK;
     objspace->heap.live_num++;
 
-    if (lev > GC_LEVEL_MAX || (lev == 0 && stack_check(STACKFRAME_FOR_GC_MARK))) {
-	if (!mark_stack_overflow) {
-	    if (mark_stack_ptr - mark_stack < MARK_STACK_MAX) {
-		*mark_stack_ptr = ptr;
-		mark_stack_ptr++;
-	    }
-	    else {
-		mark_stack_overflow = 1;
-	    }
-	}
-	return;
-    }
+    /* if (lev > GC_LEVEL_MAX || (lev == 0 && stack_check(STACKFRAME_FOR_GC_MARK))) { */
+    /*     if (!mark_stack_overflow) { */
+    /*         if (mark_stack_ptr - mark_stack < MARK_STACK_MAX) { */
+    /*     	*mark_stack_ptr = ptr; */
+    /*     	mark_stack_ptr++; */
+    /*         } */
+    /*         else { */
+    /*     	mark_stack_overflow = 1; */
+    /*         } */
+    /*     } */
+    /*     return; */
+    /* } */
     gc_mark_children(objspace, ptr, lev+1);
 }
 
@@ -2478,14 +2478,14 @@ gc_marks(rb_objspace_t *objspace)
     rb_gc_mark_unlinked_live_method_entries(th->vm);
 
     /* gc_mark objects whose marking are not completed*/
-    while (!MARK_STACK_EMPTY) {
-	if (mark_stack_overflow) {
-	    gc_mark_all(objspace);
-	}
-	else {
-	    gc_mark_rest(objspace);
-	}
-    }
+    /* while (!MARK_STACK_EMPTY) { */
+    /*     if (mark_stack_overflow) { */
+    /*         gc_mark_all(objspace); */
+    /*     } */
+    /*     else { */
+    /*         gc_mark_rest(objspace); */
+    /*     } */
+    /* } */
     GC_PROF_MARK_TIMER_STOP;
 }
 

--- a/gc_threading.c
+++ b/gc_threading.c
@@ -4,7 +4,7 @@
 #include <stdio.h>
 #include <pthread.h>
 
-#define NTHREADS 1
+#define NTHREADS 4
 #define GLOBAL_QUEUE_SIZE 500 /*TODO*/
 #define GLOBAL_QUEUE_SIZE_MIN (GLOBAL_QUEUE_SIZE / 4)
 #define LOCAL_QUEUE_SIZE 200 /*TODO*/

--- a/unittest/deque_test.c
+++ b/unittest/deque_test.c
@@ -1,0 +1,254 @@
+#include <stdarg.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <assert.h>
+#include "gc_threading.c"
+
+typedef struct test_case_t {
+    VALUE* test_vals;
+    VALUE* expected_vals;
+    int test_length;
+    int max_buf_size;
+    deque_t* deque;
+} TestCase;
+void dump_deque(deque_t* dq);
+void init_test_case(TestCase* test, 
+                    VALUE* test_vals,
+                    VALUE* expected_vals,
+                    int test_length,
+                    int max_buf_size
+                    ) {
+    test->test_vals = test_vals;
+    test->expected_vals = expected_vals;
+    test->test_length = test_length;
+    test->max_buf_size = max_buf_size;
+
+    test->deque = malloc(sizeof(deque_t));
+    deque_init(test->deque, test->max_buf_size);
+}
+
+/* Returns 1 in case of error, 0 otherwise */
+int assert_equals(int actual, int expected, const char* msg) {
+    if (actual != expected) {
+        if (msg)
+            printf("%s\n", msg);
+        printf("Expected %d, got %d\n", expected, actual);
+        return 1;
+    }
+    else {
+        printf("Assertion passed\n");
+        return 0;
+    }
+}
+
+void destroy_test_case(TestCase* test) {
+    deque_destroy(test->deque);
+}
+
+void do_deque_push_test_call(TestCase* test_case) {
+    int i, success;
+
+    for (i = 0; i < test_case->test_length; i++) {
+        success = deque_push(test_case->deque, test_case->test_vals[i]);
+        assert(success);
+    }
+}
+
+VALUE do_deque_pop_test_call(TestCase* test_case) {
+    return deque_pop(test_case->deque);
+}
+
+/* Ensure that the deque has the length specified by the test_case */
+int check_deque_length(TestCase* test_case) {
+    return assert_equals(test_case->deque->length,
+                  test_case->test_length,
+                  "Deque_Push failed to properly maintain length\n");
+}
+
+/* Ensure that the contents of the deque are those specified by the test_case */
+int check_deque_contents(TestCase* test_case) {
+    int deque_index, i;
+    VALUE expected, actual;
+    deque_t* deque = test_case->deque;
+
+    if (assert_equals(deque->length, test_case->test_length, NULL)) {
+        return 1;
+    }
+    for (i = 0; i < test_case->test_length; i++) {      
+        deque_index = (deque->head + i) % deque->max_length;
+        actual = deque->buffer[deque_index];
+        expected = test_case->expected_vals[i];
+
+        if (actual != expected) {
+            printf("Expected %lu; got %lu\n", expected, actual);
+            printf("Deque is: "); dump_deque(deque); printf("\n");
+            return 1;
+        }
+    }
+    return 0;
+}
+
+int do_deque_push_test(TestCase* test_case) {
+   
+    do_deque_push_test_call(test_case);
+
+    return check_deque_length(test_case) ||
+        check_deque_contents(test_case);    
+}
+
+void dump_deque(deque_t* dq) {
+    int i;
+    printf("[");
+    for(i = 0; i < dq->max_length - 1; i++) {
+        printf("%lu, ", dq->buffer[i]);
+    }
+    printf("%ul", dq->buffer[i]);
+    printf("]\n");
+}
+
+int test_deque_push_with_wrap() {
+    TestCase t;
+    TestCase* test = &t;
+    VALUE test_vals[3] = {1,2,3};
+    printf("test_deque_push_with_wrap:\n");
+    init_test_case(test,
+                   test_vals,
+                   test_vals,                   
+                   3,
+                   4);
+    test->deque->head = 2;
+    test->deque->tail = 2;
+    return do_deque_push_test(test);
+}
+
+int test_deque_push_maintains_tail_properly() {
+    TestCase t;
+    TestCase* test = &t;
+    VALUE test_vals[3] = {1,2,3};
+    printf("test_deque_push_maintains_tail_properly:\n");
+    init_test_case(test,
+                   test_vals,
+                   test_vals,                   
+                   3,
+                   4);
+    do_deque_push_test_call(test);
+ 
+    return assert_equals(test->deque->tail,
+                         2,
+                         "deque_push failed to maintain tail properly");
+}
+
+int test_deque_push_maintains_tail_properly_with_wrap() {
+    TestCase t;
+    TestCase* test = &t;
+    VALUE test_vals[2] = {1,2};
+    printf("test_deque_push_maintains_tail_properly_with_wrap:\n");
+    init_test_case(test,
+                   test_vals,
+                   test_vals,                   
+                   2,
+                   4);
+    do_deque_push_test_call(test);
+    
+    test->deque->head = 2;
+    test->deque->tail = 2;
+    return assert_equals(test->deque->tail,
+                         1,
+                         "deque_push failed to maintain tail properly");
+}
+
+void set_deque_state_for_pop_test(TestCase* t) {
+    int i;
+    deque_t* deque = t->deque;
+    deque->head = 0;
+    deque->tail = t->test_length - 1;
+    deque->length = t->test_length;
+    for(i = 0; i < t->test_length; i++) {
+        deque->buffer[i] = t->test_vals[i];
+    }
+}
+
+int check_pop_results(TestCase* test) {
+    int i, errors = 0;
+    for (i = 0; i < test->test_length; i++) {
+        errors += assert_equals(do_deque_pop_test_call(test), 
+                                test->expected_vals[i],
+                                NULL
+                                );
+    }
+    return errors;
+}
+
+
+int test_deque_pop_returns_right_values() {
+    TestCase t;
+    int i, errors = 0;
+    TestCase* test = &t;
+
+    VALUE test_vals[2] = {1,2};
+    VALUE expected_vals[2] = {2, 1};
+    printf("test_deque_pop_returns_right_values:\n");
+    init_test_case(test,
+                   test_vals,
+                   expected_vals,                   
+                   2,
+                   4);
+    set_deque_state_for_pop_test(test);
+    
+    return check_pop_results(test) != 0;
+}
+
+
+int test_deque_pop_maintains_tail_with_wrap() {
+    TestCase t;
+    TestCase* test = &t;
+    deque_t* deque;
+    int i, errors = 0;
+
+    printf("test_deque_pop_returns_right_values:\n");
+    init_test_case(test,
+                   NULL,
+                   NULL,                   
+                   3,
+                   3);
+    deque = test->deque;
+    deque->length = 2;
+    deque->head = 2;
+    deque->tail = 0;
+    deque_pop(deque);
+    return assert_equals(test->deque->tail, 2, NULL);
+}
+
+
+int test_wraparound() {  
+    return 0;
+}
+
+
+int main (int ARGC, char** ARGV) { 
+    int failures = 0;
+    int num_tests = 3;
+    TestCase tests[num_tests];
+
+    VALUE test_vals[5] = {1,2,3, 4, 5};
+    VALUE expected_vals[5] = {1, 2, 3, 4, 5};
+    init_test_case(&tests[0],
+                   test_vals,
+                   expected_vals,
+                   5,
+                   10);
+    failures += test_deque_push_with_wrap();
+    failures += test_deque_push_maintains_tail_properly();
+
+    failures += test_deque_pop_returns_right_values();
+    failures += test_deque_pop_maintains_tail_with_wrap();
+    printf("Got %d failures\n", failures);
+    /* init_test_case(&tests[1], */
+    /*                {1}, */
+    /*                {1,2,3}, */
+    /*                3, */
+    /*                5); */
+    /* do_test(&tests[1]); */
+
+    return failures == 0;
+}

--- a/unittest/deque_test.c
+++ b/unittest/deque_test.c
@@ -45,9 +45,9 @@ void destroy_test_case(TestCase* test) {
     deque_destroy(test->deque);
 }
 
+
 void do_deque_push_test_call(TestCase* test_case) {
     int i, success;
-
     for (i = 0; i < test_case->test_length; i++) {
         success = deque_push(test_case->deque, test_case->test_vals[i]);
         assert(success);
@@ -102,7 +102,7 @@ void dump_deque(deque_t* dq) {
     for(i = 0; i < dq->max_length - 1; i++) {
         printf("%lu, ", dq->buffer[i]);
     }
-    printf("%ul", dq->buffer[i]);
+    printf("%lu", dq->buffer[i]);
     printf("]\n");
 }
 
@@ -119,6 +119,16 @@ int test_deque_push_with_wrap() {
     test->deque->head = 2;
     test->deque->tail = 2;
     return do_deque_push_test(test);
+}
+
+int test_pos_mod() {
+    int errors = 0;
+    printf("test_pos_mod:\n");
+    errors += assert_equals(POS_MOD(3, 4), 3, NULL);
+    errors += assert_equals(POS_MOD(5, 4), 1, NULL);
+    errors += assert_equals(POS_MOD(-1, 4), 3, NULL);
+    errors += assert_equals(POS_MOD(-5, 4), 3, NULL);
+    return errors != 0;
 }
 
 int test_deque_push_maintains_tail_properly() {
@@ -242,13 +252,8 @@ int main (int ARGC, char** ARGV) {
 
     failures += test_deque_pop_returns_right_values();
     failures += test_deque_pop_maintains_tail_with_wrap();
+    failures += test_pos_mod();
     printf("Got %d failures\n", failures);
-    /* init_test_case(&tests[1], */
-    /*                {1}, */
-    /*                {1,2,3}, */
-    /*                3, */
-    /*                5); */
-    /* do_test(&tests[1]); */
 
     return failures == 0;
 }

--- a/unittest/mocks.c
+++ b/unittest/mocks.c
@@ -1,0 +1,40 @@
+#include "ruby/ruby.h"
+#include <pthread.h>
+#include <stdlib.h>
+/* 
+ * Mocks for functions defined in gc.c
+ */
+
+
+/* typedef struct tsafe_st_table_t { */
+/*     st_table* table; */
+/*     pthread_mutex_t lock; */
+/* } tsafe_st_table_t; */
+
+
+/* tsafe_st_table_t* tsafe_st_table_new () { */
+/*     tsafe_st_table_t* table = (tsafe_st_table_t*) malloc(sizeof(tsafe_st_table_t)); */
+/*     tsafe_st_table_init(table); */
+/*     return table; */
+/* } */
+
+/* void tsafe_st_table_init (tsafe_st_table_t* table) { */
+    
+/* } */
+
+
+static pthread_mutex_t marked_set_lock;
+
+extern void mocks_init() {
+    /* pthread_mutex_init(&marked_set_lock); */
+}
+
+//Want: to keep track of everything that gets marked
+//Maintain set of marked things
+
+extern void gc_do_mark(void* objspace, VALUE ptr) {
+    
+}
+extern void gc_start_mark(void* objspace) {
+
+}

--- a/unittest/test.h
+++ b/unittest/test.h
@@ -1,0 +1,9 @@
+#include "ruby/st.h"
+/* Return the set of all things marked */
+extern st_table* get_marked_set();
+
+
+/* Initialize data used by the mocking functions internally. */
+extern void mocks_init();
+
+


### PR DESCRIPTION
Explanation is mostly in the title.

The bugs in question are these: 
1. mod in C with a negative number will return a negative number, which was not what I expected. I replaced naive calls to mod in the deque code with a macro that works the way I wanted (the way that Python behaves).
1. The code to push and pop from the global queue didn't correctly check whether it could in fact pull/push as much as it wanted to from the queue.
2. The call to pthread_mutex_trylock wasn't checked properly--it returns 0 on success, but the conditional treated it as if it returned 1 when locking succeed.

There remain memory errors; valgrind keeps telling me things about reads in freed blocks, which probably means we're missing some objects in our mark. I'm implementing a testing framework to compare against the single threaded implementation to work on this.
