### PR TITLE
Supports switching between serial / parallel / both (for comparison)

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -1626,6 +1626,7 @@ rb_gc_mark_maybe(VALUE obj)
 static void
 gc_mark_object(rb_objspace_t *objspace, VALUE ptr, int lev)
 {
+    GC_TEST_LOG("%lu\n", ptr);
     register RVALUE *obj;
 
     obj = RANY(ptr);

--- a/gc.c
+++ b/gc.c
@@ -1652,9 +1652,6 @@ gc_mark_object(rb_objspace_t *objspace, VALUE ptr, int lev)
     gc_mark_children(objspace, ptr, lev+1);
 }
 
-/** Defined in gc_threading.c */
-extern void gc_mark_defer(rb_objspace_t *objspace, VALUE ptr, int lev);
-
 static void
 gc_mark(rb_objspace_t *objspace, VALUE ptr, int lev) {
     if (gc_defer_mark) {
@@ -2170,8 +2167,6 @@ rest_sweep(rb_objspace_t *objspace)
        after_gc_sweep(objspace);
     }
 }
-
-extern void gc_markall(void* objspace);
 
 static void gc_marks(rb_objspace_t *objspace);
 

--- a/gc.h
+++ b/gc.h
@@ -106,4 +106,16 @@ extern void gc_mark_reset(void* objspace);
 extern void gc_do_mark(void* objspace, VALUE ptr);
 extern void gc_start_mark(void* objspace);
 
+/** Test code */
+#define GC_MARK_TEST 1
+#define TEST_LOG_PREFIX "GCTest"
+
+#if GC_MARK_TEST
+#define GC_TEST_LOG(...)                              \
+    printf(TEST_LOG_PREFIX ": " __VA_ARGS__)
+#else
+#define GC_TEST_LOG(...)              \
+    //noop
+#endif
+
 #endif /* RUBY_GC_H */

--- a/gc.h
+++ b/gc.h
@@ -96,4 +96,14 @@ void rb_objspace_each_objects(
 #pragma GCC visibility pop
 #endif
 
+/** Defined in gc_threading.c */
+extern void gc_mark_defer(void *objspace, VALUE ptr, int lev);
+extern void gc_markall(void* objspace);
+
+/** Defined in gc.c */
+extern int gc_defer_mark;
+extern void gc_mark_reset(void* objspace);
+extern void gc_do_mark(void* objspace, VALUE ptr);
+extern void gc_start_mark(void* objspace);
+
 #endif /* RUBY_GC_H */

--- a/gc_threading.c
+++ b/gc_threading.c
@@ -7,8 +7,9 @@
 #define MODE_SINGLE_THREAD 0
 #define MODE_MULTITHREAD 1
 #define MODE_DUAL 2
+#define MODE_SINGLE_THREAD_TWICE 3
 
-static int mode = MODE_DUAL;
+static int mode = MODE_SINGLE_THREAD_TWICE;
 
 #define NTHREADS 4
 #define GLOBAL_QUEUE_SIZE 500 /*TODO*/
@@ -300,9 +301,24 @@ void gc_markall(void* objspace) {
             break;
         case MODE_DUAL:
             gc_defer_mark = 1;
+            GC_TEST_LOG("A\n");
             gc_mark_parallel(objspace);
+            GC_TEST_LOG("END\n");
             gc_mark_reset(objspace);
             gc_defer_mark = 0;
+            GC_TEST_LOG("B\n");
             gc_start_mark(objspace);
+            GC_TEST_LOG("END\n");
+            break;
+        case MODE_SINGLE_THREAD_TWICE:
+            gc_defer_mark = 0;
+            GC_TEST_LOG("A\n");
+            gc_start_mark(objspace);
+            GC_TEST_LOG("END\n");
+            gc_mark_reset(objspace);
+            GC_TEST_LOG("B\n");
+            gc_start_mark(objspace);
+            GC_TEST_LOG("END\n");
+            break;
     }
 }

--- a/gc_threading.c
+++ b/gc_threading.c
@@ -1,6 +1,6 @@
 #include "ruby/ruby.h"
-#include <assert.h>
 #include "gc.h"
+#include <assert.h>
 #include <stdio.h>
 #include <pthread.h>
 
@@ -19,9 +19,9 @@ static int mode = MODE_DUAL;
 #define DEQUE_FULL 0
 #define DEQUE_EMPTY -1
 
-#define GC_THREADING_DEBUG 1
+#define GC_THREADING_DEBUG 0
 
-#ifdef GC_THREADING_DEBUG
+#if GC_THREADING_DEBUG
 #define debug_print(...)                        \
     printf(__VA_ARGS__)
 #else
@@ -37,13 +37,6 @@ static int mode = MODE_DUAL;
     ((a) < (b) ? (a) : (b))
 
 
-/** Defined in gc.c */
-extern int gc_defer_mark;
-extern void gc_mark_reset(void* objspace);
-extern void gc_do_mark(void* objspace, VALUE ptr);
-extern void gc_start_mark(void* objspace);
-
-pthread_key_t thread_id_k;
 /**
  * Deque
  */
@@ -217,6 +210,7 @@ static void global_queue_offer_work(global_queue_t* global_queue, deque_t* local
 void* active_objspace;
 global_queue_t* global_queue;
 pthread_key_t thread_local_deque_k;
+pthread_key_t thread_id_k;
 
 static void* mark_run_loop(void* arg) {
     long thread_id = (long) arg;

--- a/method.h
+++ b/method.h
@@ -99,6 +99,7 @@ int rb_method_entry_eq(const rb_method_entry_t *m1, const rb_method_entry_t *m2)
 
 void rb_mark_method_entry(const rb_method_entry_t *me);
 void rb_free_method_entry(rb_method_entry_t *me);
+void rb_reset_method_entry(void *vm);
 void rb_sweep_method_entry(void *vm);
 void rb_free_m_table(st_table *tbl);
 

--- a/vm_method.c
+++ b/vm_method.c
@@ -110,6 +110,24 @@ rb_gc_mark_unlinked_live_method_entries(void *pvm)
 }
 
 void
+rb_reset_method_entry(void *pvm)
+{
+    rb_vm_t *vm = pvm;
+    struct unlinked_method_entry_list_entry *ume = vm->unlinked_method_entry_list, *prev_ume = 0, *curr_ume;
+
+    while (ume) {
+	if (ume->me->mark) {
+	    ume->me->mark = 0;
+	    prev_ume = ume;
+	    ume = ume->next;
+	}
+	else {
+	    // Do Nothing!
+	}
+    }
+}
+
+void
 rb_sweep_method_entry(void *pvm)
 {
     rb_vm_t *vm = pvm;

--- a/vm_method.c
+++ b/vm_method.c
@@ -113,17 +113,11 @@ void
 rb_reset_method_entry(void *pvm)
 {
     rb_vm_t *vm = pvm;
-    struct unlinked_method_entry_list_entry *ume = vm->unlinked_method_entry_list, *prev_ume = 0, *curr_ume;
+    struct unlinked_method_entry_list_entry *ume = vm->unlinked_method_entry_list;
 
     while (ume) {
-	if (ume->me->mark) {
-	    ume->me->mark = 0;
-	    prev_ume = ume;
-	    ume = ume->next;
-	}
-	else {
-	    // Do Nothing!
-	}
+	ume->me->mark = 0;
+	ume = ume->next;
     }
 }
 


### PR DESCRIPTION
The mode flag in gc_threading switches between serial marking, parallel marking, and serial + parallel for comparison purposes.

It seems to have introduced a regression; miniruby now segfaults. Insights welcome!
