### PR TITLE
Some bug fixes

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -48,7 +48,7 @@ empty =
 OUTFLAG = @OUTFLAG@$(empty)
 COUTFLAG = @COUTFLAG@$(empty)
 ARCH_FLAG = @ARCH_FLAG@
-CFLAGS = @CFLAGS@ $(ARCH_FLAG)
+CFLAGS = @CFLAGS@ $(ARCH_FLAG) $(GC_OPTS)
 cflags = @cflags@
 optflags = @optflags@
 debugflags = @debugflags@
@@ -162,7 +162,9 @@ all:
 miniruby$(EXEEXT):
 		@-if test -f $@; then $(MV) -f $@ $@.old; $(RM) $@.old; fi
 		$(ECHO) linking $@
-		$(Q) $(PURIFY) $(CC) $(LDFLAGS) $(XLDFLAGS) $(MAINLIBS) $(NORMALMAINOBJ) $(MINIOBJS) $(COMMONOBJS) $(DMYEXT) $(LIBS) $(OUTFLAG)$@
+		$(ECHO) $(Q) $(PURIFY) $(CC) ${GC_OPTS} $(LDFLAGS) $(XLDFLAGS) $(MAINLIBS) $(NORMALMAINOBJ) $(MINIOBJS) $(COMMONOBJS) $(DMYEXT) $(LIBS) $(OUTFLAG)$@
+
+		$(Q) $(PURIFY) $(CC) ${GC_OPTS} $(LDFLAGS) $(XLDFLAGS) $(MAINLIBS) $(NORMALMAINOBJ) $(MINIOBJS) $(COMMONOBJS) $(DMYEXT) $(LIBS) $(OUTFLAG)$@
 
 $(PROGRAM):
 		@$(RM) $@

--- a/bench.rb
+++ b/bench.rb
@@ -1,0 +1,58 @@
+#!/usr/bin/env ruby
+
+RESULTS_DIR = "./bench_results"
+BENCH_DIR = "./benchmark"
+GOOD_BENCH = "./miniruby_bench"
+MAX_THREADS = 2
+
+def bench(script, nthreads) 
+  bench_pattern = /bm_(.*?\.rb)/
+  match = bench_pattern.match(script)
+  if not match
+    return
+  end
+
+  prepare_script = "prepare_#{match[1]}"
+  
+  bench_out = "#{RESULTS_DIR}/#{script}_#{nthreads}_out"
+  puts "Benching #{script}"
+  
+  if File.exist? prepare_script
+    system ruby #{BENCH_DIR}/#{prepare_script}
+  end
+
+  retval = system "./miniruby #{BENCH_DIR}/#{script} > #{bench_out}"
+
+  if retval
+    puts "#{script} succeeded"
+    `cp ./benchmark/#{script} #{GOOD_BENCH}`        
+  else
+    puts("#{script} failed")
+    `rm #{bench_out}`
+  end 
+end
+
+ 
+def compile(nthreads)
+  system "make clean"
+  system("make GC_OPTS=\"-DNTHREADS=#{nthreads} -DBENCH=1\" miniruby")   
+end
+
+
+def bench_all
+  `mkdir -p #{RESULTS_DIR}`
+  `mkdir -p #{GOOD_BENCH}`
+
+  (1..MAX_THREADS).each do |nthreads|
+    puts "Benching with #{nthreads} threads..."
+    compile(nthreads)
+    Dir.new(BENCH_DIR).each do |script|
+      if File.directory? script 
+        next 
+      end
+      bench(script, nthreads)      
+    end
+  end
+end
+
+bench_all

--- a/bench.rb
+++ b/bench.rb
@@ -3,7 +3,7 @@
 RESULTS_DIR = "./bench_results"
 BENCH_DIR = "./benchmark"
 GOOD_BENCH = "./miniruby_bench"
-MAX_THREADS = 2
+MAX_THREADS = 16
 
 def bench(script, nthreads) 
   bench_pattern = /bm_(.*?\.rb)/

--- a/bench.sh
+++ b/bench.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+make clean
+make miniruby
+RESULTS_DIR=./bench_results
+GOOD_BENCH=./miniruby_bench
+mkdir -p $RESULTS_DIR
+mkdir -p 
+for script in `ls ./benchmark`;
+do
+    bench_out=$RESULTS_DIR/$script"_out"
+    echo Benching $script
+    ./miniruby ./benchmark/$script > $bench_out
+
+    RETVAL=$?
+    if [ $RETVAL -eq 0 ] 
+        then
+        cp ./benchmark/$script $GOOD_BENCH
+        
+    else
+        echo $script failed
+        rm $bench_out
+    fi
+done
+
+

--- a/extract_results.rb
+++ b/extract_results.rb
@@ -1,0 +1,90 @@
+require 'csv'
+MAX_THREADS = 16
+
+def parse_file_name(fname)
+  pattern = /(.*?)\.rb_(\d+)_out/
+  
+  match = pattern.match(fname)
+  
+  if match.nil?
+    throw ArgumentError.new("Bad filename")
+  end
+
+  return match[1..2]
+end
+
+
+
+#nthreads bench bench
+
+def extract_times(fname)
+  num_calls = 0
+  times = 0.0
+  results = Hash.new {|hash, key| hash[key] = [0, 0.0] }
+
+  File.open(fname) do |f|
+    f.each_line do |l|
+      parsed = parse_line(l)
+      if not parsed
+        next
+      end      
+
+      if parsed[:time] < 0
+        next
+      end
+      res = results[parsed[:type]] 
+      res[0] += 1
+      res[1] += parsed[:time]
+    end
+  end
+  
+  avgs = Hash[results.each_pair.map do |key, res|
+    [key, res[1] / res[0]] unless res[0] == 0
+  end]
+
+  return avgs
+end
+
+
+def extract_all
+  CSV.open("./results.csv", 'wb') do |csv|
+    serial_done = false
+    csv << ["nthreads"] + Dir.glob("./miniruby_bench/*.rb")
+    (1..MAX_THREADS).each do |i|
+      row = [i]
+      serial_row = ["serial"]
+      Dir.glob("./bench_results/*.rb_#{i}_out").each do |fname|
+        res = extract_times(fname)
+
+        serial_row << res[:serial]
+        row << res[:parallel]
+      end
+
+      if not serial_done
+        serial_done = true
+        csv << serial_row        
+      end
+      csv << row
+    end
+  end
+end
+
+def parse_line(l)
+  rtn = Hash.new
+
+  par_pattern = /(gc_mark_parallel)\(objspace\):(.*)/
+  serial_pattern = /(gc_start_mark)\(objspace\):(.*)/
+
+  begin 
+    match = par_pattern.match(l) || serial_pattern.match(l)
+  rescue
+    match = nil
+  end
+  return nil unless match
+  rtn[:type] = match[1] == "gc_mark_parallel" ? :parallel : :serial
+  rtn[:time] = match[2].to_f
+  
+  return rtn
+end
+
+extract_all

--- a/gc-test/comparison_test.rb
+++ b/gc-test/comparison_test.rb
@@ -1,0 +1,39 @@
+#!/usr/bin/env ruby
+
+require 'set'
+
+TEST_LINE_PATTERN = /^GCTest:(.*)$/
+
+def extract_marked_sets
+  first_run = Set.new
+  second_run = Set.new
+  cur_set = first_run
+  ARGF.each_line do |l|
+    match = TEST_LINE_PATTERN.match(l) 
+    next unless match
+    
+    payload = match[1].strip
+
+    case payload
+    when "A"
+      cur_set = first_run
+    when "B"
+      cur_set = second_run
+    when /\d+/
+      cur_set << payload.to_i
+    when "END"
+      next
+    else
+      raise ArgumentError.new("Couldn't recognize payload: #{payload}")
+    end
+  end
+
+  if first_run != second_run
+    puts "Got differences between runs"
+    puts "Only in first: #{(first_run - second_run).to_a.join("\n")}"
+    puts "Only in second: #{(second_run - first_run).to_a.join("\n")}"
+  end
+
+end
+
+extract_marked_sets

--- a/gc.h
+++ b/gc.h
@@ -101,14 +101,15 @@ extern void gc_mark_defer(void *objspace, VALUE ptr, int lev);
 extern void gc_markall(void* objspace);
 
 /** Defined in gc.c */
-extern int gc_defer_mark;
+extern pthread_key_t gc_defer_mark_key;
 extern void gc_mark_reset(void* objspace);
 extern void gc_do_mark(void* objspace, VALUE ptr);
 extern void gc_start_mark(void* objspace);
 
 /** Test code */
-#define GC_MARK_TEST 1
+#define GC_MARK_TEST 0
 #define TEST_LOG_PREFIX "GCTest"
+
 
 #if GC_MARK_TEST
 #define GC_TEST_LOG(...)                              \
@@ -117,5 +118,13 @@ extern void gc_start_mark(void* objspace);
 #define GC_TEST_LOG(...)              \
     //noop
 #endif
+
+/* Helper macros */
+//Type of 
+#define SET_GC_DEFER_MARK(_val)                                         \
+    assert(pthread_setspecific(gc_defer_mark_key, (void*) _val) == 0)
+
+#define GET_GC_DEFER_MARK()                     \
+    ((long) pthread_getspecific(gc_defer_mark_key))
 
 #endif /* RUBY_GC_H */

--- a/gc_threading.c
+++ b/gc_threading.c
@@ -134,7 +134,7 @@ static VALUE deque_pop_back(deque_t* deque) {
   assert(index >= 0);
   rtn = deque->buffer[index];
 
-  deque->head = POS_MOD(deque->head - 1, deque->max_length);
+  deque->head = POS_MOD(deque->head + 1, deque->max_length);
 
   deque->length--;
   return rtn;

--- a/gc_threading.c
+++ b/gc_threading.c
@@ -30,7 +30,7 @@ static int mode = MODE_DUAL;
     double _diff;                                                       
 
 
-#ifdef BENCH
+#if BENCH
 #define TIME(_call)                                                     \
     do {                                                                \
         gettimeofday(&_start, NULL);                                    \

--- a/gc_threading.c
+++ b/gc_threading.c
@@ -30,7 +30,6 @@ static int mode = MODE_DUAL;
     double _diff;                                                       
 
 
-
 #ifdef BENCH
 #define TIME(_call)                                                     \
     do {                                                                \
@@ -42,7 +41,7 @@ static int mode = MODE_DUAL;
     }  while(0);    
 #else 
 #define TIME(_call)                             \
-    //noop
+    _call
 #endif
 
 

--- a/gc_threading.c
+++ b/gc_threading.c
@@ -42,10 +42,10 @@ static int mode = MODE_SINGLE_THREAD_TWICE;
  * Deque
  */
 
-#define ASSERT_SANE_DEQUE(d) {\
-  assert(d != NULL);\
-  assert(d->max_length >= 0);\
-}
+#define ASSERT_SANE_DEQUE(d) do {               \
+        assert(d != NULL);                      \
+        assert(d->max_length >= 0);             \
+    } while(0);
 
 typedef struct deque_struct {
     VALUE* buffer;

--- a/unittest/deque_test.c
+++ b/unittest/deque_test.c
@@ -255,5 +255,5 @@ int main (int ARGC, char** ARGV) {
     failures += test_pos_mod();
     printf("Got %d failures\n", failures);
 
-    return failures == 0;
+    return failures != 0;
 }

--- a/unittest/deque_test.c
+++ b/unittest/deque_test.c
@@ -58,6 +58,11 @@ VALUE do_deque_pop_test_call(TestCase* test_case) {
     return deque_pop(test_case->deque);
 }
 
+VALUE do_deque_pop_back_test_call(TestCase* test_case) {
+    return deque_pop_back(test_case->deque);
+}
+
+
 /* Ensure that the deque has the length specified by the test_case */
 int check_deque_length(TestCase* test_case) {
     return assert_equals(test_case->deque->length,
@@ -189,10 +194,20 @@ int check_pop_results(TestCase* test) {
     return errors;
 }
 
+int check_pop_back_results(TestCase* test) {
+    int i, errors = 0;
+    for (i = 0; i < test->test_length; i++) {
+        errors += assert_equals(do_deque_pop_back_test_call(test), 
+                                test->expected_vals[i],
+                                NULL
+                                );
+    }
+    return errors;
+}
+
 
 int test_deque_pop_returns_right_values() {
     TestCase t;
-    int i, errors = 0;
     TestCase* test = &t;
 
     VALUE test_vals[2] = {1,2};
@@ -213,7 +228,7 @@ int test_deque_pop_maintains_tail_with_wrap() {
     TestCase t;
     TestCase* test = &t;
     deque_t* deque;
-    int i, errors = 0;
+
 
     printf("test_deque_pop_returns_right_values:\n");
     init_test_case(test,
@@ -230,6 +245,44 @@ int test_deque_pop_maintains_tail_with_wrap() {
 }
 
 
+int test_deque_pop_back_returns_right_values() {
+    TestCase t;
+    TestCase* test = &t;
+    VALUE test_vals[2] = {1,2};
+    VALUE expected_vals[2] = {1, 2};
+    printf("test_deque_pop_back_returns_right_values:\n");
+
+    init_test_case(test,
+                   test_vals,
+                   expected_vals,                   
+                   2,
+                   4);
+    set_deque_state_for_pop_test(test);
+    
+    return check_pop_back_results(test) != 0;
+}
+
+int test_deque_pop_back_maintains_head_with_wrap() {
+    TestCase t;
+    TestCase* test = &t;
+    deque_t* deque;
+    int errors = 0;
+
+    printf("test_deque_pop_back_maintains_head_with_wrap\n");
+    init_test_case(test,
+                   NULL,
+                   NULL,                   
+                   3,
+                   3);
+    deque = test->deque;
+    deque->length = 2;
+    deque->head = 2;
+    deque->tail = 0;
+    deque_pop_back(deque);
+    return assert_equals(test->deque->head, 0, NULL);
+}
+
+
 int test_wraparound() {  
     return 0;
 }
@@ -237,21 +290,14 @@ int test_wraparound() {
 
 int main (int ARGC, char** ARGV) { 
     int failures = 0;
-    int num_tests = 3;
-    TestCase tests[num_tests];
 
-    VALUE test_vals[5] = {1,2,3, 4, 5};
-    VALUE expected_vals[5] = {1, 2, 3, 4, 5};
-    init_test_case(&tests[0],
-                   test_vals,
-                   expected_vals,
-                   5,
-                   10);
     failures += test_deque_push_with_wrap();
     failures += test_deque_push_maintains_tail_properly();
 
     failures += test_deque_pop_returns_right_values();
     failures += test_deque_pop_maintains_tail_with_wrap();
+    failures += test_deque_pop_back_returns_right_values();
+    failures += test_deque_pop_back_maintains_head_with_wrap();
     failures += test_pos_mod();
     printf("Got %d failures\n", failures);
 

--- a/unittest/mocks.c
+++ b/unittest/mocks.c
@@ -6,22 +6,6 @@
  */
 
 
-/* typedef struct tsafe_st_table_t { */
-/*     st_table* table; */
-/*     pthread_mutex_t lock; */
-/* } tsafe_st_table_t; */
-
-
-/* tsafe_st_table_t* tsafe_st_table_new () { */
-/*     tsafe_st_table_t* table = (tsafe_st_table_t*) malloc(sizeof(tsafe_st_table_t)); */
-/*     tsafe_st_table_init(table); */
-/*     return table; */
-/* } */
-
-/* void tsafe_st_table_init (tsafe_st_table_t* table) { */
-    
-/* } */
-
 
 static pthread_mutex_t marked_set_lock;
 
@@ -29,8 +13,6 @@ extern void mocks_init() {
     /* pthread_mutex_init(&marked_set_lock); */
 }
 
-//Want: to keep track of everything that gets marked
-//Maintain set of marked things
 
 extern void gc_do_mark(void* objspace, VALUE ptr) {
     
@@ -38,3 +20,7 @@ extern void gc_do_mark(void* objspace, VALUE ptr) {
 extern void gc_start_mark(void* objspace) {
 
 }
+
+int gc_defer_mark = 1;
+
+

--- a/unittest/mocks.c
+++ b/unittest/mocks.c
@@ -21,6 +21,10 @@ extern void gc_start_mark(void* objspace) {
 
 }
 
+extern void gc_mark_reset(void* objspace) {
+    
+}
+
 int gc_defer_mark = 1;
 
 


### PR DESCRIPTION
2 bugs, 2 fixes:
1. deque_pop_back was subtracting from deque->head instead of adding to it (tail is the one that moves when a push happens, so popping (dequeuing really) from the opposite end should move head forward). I may rename this function for clarity. Unittest has been added to catch the bug--run "make gc-unittest"
2. Made gc_mark_defer unset gc_defer_mark before falling back onto the recursive original code.

@Max--see if this one will run ok on your machine.
